### PR TITLE
Install mobility on MindCard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'faker'
 gem 'mini_racer', platforms: :ruby
 gem 'simple_form'
 gem 'font-awesome-sass', '~> 6.1.1'
+gem 'mobility', '~> 1.2.6'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,9 @@ GEM
     mini_racer (0.6.2)
       libv8-node (~> 16.10.0.0)
     minitest (5.15.0)
+    mobility (1.2.6)
+      i18n (>= 0.6.10, < 2)
+      request_store (~> 1.0)
     msgpack (1.5.2)
     nio4r (2.5.8)
     nokogiri (1.13.6-x86_64-darwin)
@@ -174,6 +177,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (2.5.0)
+    request_store (1.5.1)
+      rack (>= 1.4)
     rexml (3.2.5)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
@@ -278,6 +283,7 @@ DEPENDENCIES
   jquery-rails
   listen (~> 3.2)
   mini_racer
+  mobility (~> 1.2.6)
   pry
   puma (~> 4.1)
   rails (~> 6.0.5)

--- a/app/models/mind_card.rb
+++ b/app/models/mind_card.rb
@@ -1,3 +1,5 @@
 class MindCard < ApplicationRecord
+  extend Mobility
   validates :title, presence: true
+  translates :text, :context, :pronunciation
 end

--- a/config/initializers/mobility.rb
+++ b/config/initializers/mobility.rb
@@ -1,0 +1,116 @@
+Mobility.configure do
+  # PLUGINS
+  plugins do
+    # Backend
+    #
+    # Sets the default backend to use in models. This can be overridden in models
+    # by passing +backend: ...+ to +translates+.
+    #
+    # To default to a different backend globally, replace +:key_value+ by another
+    # backend name.
+    #
+    backend :table
+
+    # ActiveRecord
+    #
+    # Defines ActiveRecord as ORM, and enables ActiveRecord-specific plugins.
+    active_record
+
+    # Accessors
+    #
+    # Define reader and writer methods for translated attributes. Remove either
+    # to disable globally, or pass +reader: false+ or +writer: false+ to
+    # +translates+ in any translated model.
+    #
+    reader
+    writer
+
+    # Backend Reader
+    #
+    # Defines reader to access the backend for any attribute, of the form
+    # +<attribute>_backend+.
+    #
+    backend_reader
+    #
+    # Or pass an interpolation string to define a different pattern:
+    # backend_reader "%s_translations"
+
+    # Query
+    #
+    # Defines a scope on the model class which allows querying on
+    # translated attributes. The default scope is named +i18n+, pass a different
+    # name as default to change the global default, or to +translates+ in any
+    # model to change it for that model alone.
+    #
+    query
+
+    # Cache
+    #
+    # Comment out to disable caching reads and writes.
+    #
+    cache
+
+    # Dirty
+    #
+    # Uncomment this line to include and enable globally:
+    # dirty
+    #
+    # Or uncomment this line to include but disable by default, and only enable
+    # per model by passing +dirty: true+ to +translates+.
+    # dirty false
+
+    # Fallbacks
+    #
+    # Uncomment line below to enable fallbacks, using +I18n.fallbacks+.
+    # fallbacks
+    #
+    # Or uncomment this line to enable fallbacks with a global default.
+    # fallbacks { :pt => :en }
+
+    # Presence
+    #
+    # Converts blank strings to nil on reads and writes. Comment out to
+    # disable.
+    #
+    presence
+
+    # Default
+    #
+    # Set a default translation per attributes. When enabled, passing +default:
+    # 'foo'+ sets a default translation string to show in case no translation is
+    # present. Can also be passed a proc.
+    #
+    # default 'foo'
+
+    # Fallthrough Accessors
+    #
+    # Uses method_missing to define locale-specific accessor methods like
+    # +title_en+, +title_en=+, +title_fr+, +title_fr=+ for each translated
+    # attribute. If you know what set of locales you want to support, it's
+    # generally better to use Locale Accessors (or both together) since
+    # +method_missing+ is very slow.  (You can use both fallthrough and locale
+    # accessor plugins together without conflict.)
+    #
+    # fallthrough_accessors
+
+    # Locale Accessors
+    #
+    # Uses +def+ to define accessor methods for a set of locales. By default uses
+    # +I18n.available_locales+, but you can pass the set of locales with
+    # +translates+ and/or set a global default here.
+    #
+    # locale_accessors
+    #
+    # Or define specific defaults by uncommenting line below
+    locale_accessors [:en, :da, :fr]
+
+    # Attribute Methods
+    #
+    # Adds translated attributes to +attributes+ hash, and defines methods
+    # +translated_attributes+ and +untranslated_attributes+ which return hashes
+    # with translated and untranslated attributes, respectively. Be aware that
+    # this plugin can create conflicts with other gems.
+    #
+    # attribute_methods
+  end
+end

--- a/db/migrate/20220614195952_create_text_translations.rb
+++ b/db/migrate/20220614195952_create_text_translations.rb
@@ -1,0 +1,13 @@
+class CreateTextTranslations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :mobility_text_translations do |t|
+      t.string :locale, null: false
+      t.string :key,    null: false
+      t.text :value
+      t.references :translatable, polymorphic: true, index: false
+      t.timestamps null: false
+    end
+    add_index :mobility_text_translations, [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_text_translations_on_keys
+    add_index :mobility_text_translations, [:translatable_id, :translatable_type, :key], name: :index_mobility_text_translations_on_translatable_attribute
+  end
+end

--- a/db/migrate/20220614195953_create_string_translations.rb
+++ b/db/migrate/20220614195953_create_string_translations.rb
@@ -1,0 +1,14 @@
+class CreateStringTranslations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :mobility_string_translations do |t|
+      t.string :locale, null: false
+      t.string :key, null: false
+      t.string :value
+      t.references :translatable, polymorphic: true, index: false
+      t.timestamps null: false
+    end
+    add_index :mobility_string_translations, [:translatable_id, :translatable_type, :locale, :key], unique: true, name: :index_mobility_string_translations_on_keys
+    add_index :mobility_string_translations, [:translatable_id, :translatable_type, :key], name: :index_mobility_string_translations_on_translatable_attribute
+    add_index :mobility_string_translations, [:translatable_type, :key, :value, :locale], name: :index_mobility_string_translations_on_query_keys
+  end
+end

--- a/db/migrate/20220614200947_create_mind_card_text_and_context_and_pronunciation_translations_for_mobility_table_backend.rb
+++ b/db/migrate/20220614200947_create_mind_card_text_and_context_and_pronunciation_translations_for_mobility_table_backend.rb
@@ -1,0 +1,20 @@
+class CreateMindCardTextAndContextAndPronunciationTranslationsForMobilityTableBackend < ActiveRecord::Migration[6.0]
+  def change
+    create_table :mind_card_translations do |t|
+
+      # Translated attribute(s)
+      t.string :text
+      t.string :context
+      t.string :pronunciation
+
+      t.string  :locale, null: false
+      t.references :mind_card, null: false, foreign_key: true, index: false
+
+      t.timestamps null: false
+    end
+
+    add_index :mind_card_translations, :locale, name: :index_mind_card_translations_on_locale
+    add_index :mind_card_translations, [:mind_card_id, :locale], name: :index_mind_card_translations_on_mind_card_id_and_locale, unique: true
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_29_193850) do
+ActiveRecord::Schema.define(version: 2022_06_14_200947) do
+
+  create_table "mind_card_translations", force: :cascade do |t|
+    t.string "text"
+    t.string "context"
+    t.string "pronunciation"
+    t.string "locale", null: false
+    t.integer "mind_card_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["locale"], name: "index_mind_card_translations_on_locale"
+    t.index ["mind_card_id", "locale"], name: "index_mind_card_translations_on_mind_card_id_and_locale", unique: true
+  end
 
   create_table "mind_cards", force: :cascade do |t|
     t.string "title"
@@ -22,4 +34,30 @@ ActiveRecord::Schema.define(version: 2022_05_29_193850) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "mobility_string_translations", force: :cascade do |t|
+    t.string "locale", null: false
+    t.string "key", null: false
+    t.string "value"
+    t.string "translatable_type"
+    t.integer "translatable_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["translatable_id", "translatable_type", "key"], name: "index_mobility_string_translations_on_translatable_attribute"
+    t.index ["translatable_id", "translatable_type", "locale", "key"], name: "index_mobility_string_translations_on_keys", unique: true
+    t.index ["translatable_type", "key", "value", "locale"], name: "index_mobility_string_translations_on_query_keys"
+  end
+
+  create_table "mobility_text_translations", force: :cascade do |t|
+    t.string "locale", null: false
+    t.string "key", null: false
+    t.text "value"
+    t.string "translatable_type"
+    t.integer "translatable_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["translatable_id", "translatable_type", "key"], name: "index_mobility_text_translations_on_translatable_attribute"
+    t.index ["translatable_id", "translatable_type", "locale", "key"], name: "index_mobility_text_translations_on_keys", unique: true
+  end
+
+  add_foreign_key "mind_card_translations", "mind_cards"
 end


### PR DESCRIPTION
Fixes #3

### For future reference
Use the following command when creating a new translation table:
`rails generate mobility:translations post title:string content:text`
